### PR TITLE
Missing "mean" value for fitType option in help and comments

### DIFF
--- a/template_script_DESeq2.r
+++ b/template_script_DESeq2.r
@@ -25,7 +25,7 @@ varInt <- "group"                                    # factor of interest
 condRef <- "WT"                                      # reference biological condition
 batch <- NULL                                        # blocking factor: NULL (default) or "batch" for example
 
-fitType <- "parametric"                              # mean-variance relationship: "parametric" (default) or "local"
+fitType <- "parametric"                              # mean-variance relationship: "parametric" (default), "local" or "mean"
 cooksCutoff <- TRUE                                  # TRUE/FALSE to perform the outliers detection (default is TRUE)
 independentFiltering <- TRUE                         # TRUE/FALSE to perform independent filtering (default is TRUE)
 alpha <- 0.05                                        # threshold of statistical significance

--- a/template_script_DESeq2_CL.r
+++ b/template_script_DESeq2_CL.r
@@ -54,7 +54,7 @@ make_option(c("-b", "--batch"),
 make_option(c("-f", "--fitType"),
 			default="parametric",
 			dest="fitType", 
-			help="mean-variance relationship: [default: %default] or local"),
+			help="mean-variance relationship: [default: %default],local or mean"),
 
 make_option(c("-o", "--cooksCutoff"),
 			default=TRUE,
@@ -116,7 +116,7 @@ featuresToRemove <- unlist(strsplit(opt$FTR, ","))   # names of the features to 
 varInt <- opt$varInt                                 # factor of interest
 condRef <- opt$condRef                               # reference biological condition
 batch <- opt$batch                                   # blocking factor: NULL (default) or "batch" for example
-fitType <- opt$fitType                               # mean-variance relationship: "parametric" (default) or "local"
+fitType <- opt$fitType                               # mean-variance relationship: "parametric" (default), "local" or "mean"
 cooksCutoff <- opt$cooksCutoff                       # outliers detection threshold (NULL to let DESeq2 choosing it)
 independentFiltering <- opt$independentFiltering     # TRUE/FALSE to perform independent filtering (default is TRUE)
 alpha <- as.numeric(opt$alpha)                       # threshold of statistical significance


### PR DESCRIPTION
Update help and comments in DESeq2 scripts for option fitType (add "mean" value)